### PR TITLE
Changed PWM duty cycle argument to uint16_t

### DIFF
--- a/multipwm.c
+++ b/multipwm.c
@@ -111,7 +111,7 @@ void multipwm_dump_schedule(pwm_info_t *pwm_info) {
 #endif
 }
 
-void multipwm_set_duty(pwm_info_t *pwm_info, uint8_t channel, uint32_t duty) {
+void multipwm_set_duty(pwm_info_t *pwm_info, uint8_t channel, uint16_t duty) {
     if (channel >= pwm_info->channels) return;
 
     pwm_info->pins[channel].duty = duty;
@@ -196,7 +196,7 @@ void multipwm_set_duty(pwm_info_t *pwm_info, uint8_t channel, uint32_t duty) {
 
 }
 
-void multipwm_set_duty_all(pwm_info_t *pwm_info, uint32_t duty) {
+void multipwm_set_duty_all(pwm_info_t *pwm_info, uint16_t duty) {
     multipwm_stop(pwm_info);
     for (uint8_t ii=0; ii<pwm_info->channels; ii++) {
         multipwm_set_duty(pwm_info, ii, duty);

--- a/multipwm.h
+++ b/multipwm.h
@@ -17,7 +17,7 @@ extern "C" {
 
 typedef struct {
     uint8_t pin;
-    uint32_t duty;
+    uint16_t duty;
 } pwm_pin_t;
 
 typedef struct pwm_schedule {
@@ -67,14 +67,14 @@ void multipwm_set_freq(pwm_info_t *pwm_info, uint16_t freq);
  * @param channel Channel index
  * @param duty Duty value
  */
-void multipwm_set_duty(pwm_info_t *pwm_info, uint8_t channel, uint32_t duty);
+void multipwm_set_duty(pwm_info_t *pwm_info, uint8_t channel, uint16_t duty);
 
 /**
  * Set Duty for all channels between 0 and UINT16_MAX
  * @param pwm_info Pointer to pwm_info
  * @param duty Duty value
  */
-void multipwm_set_duty_all(pwm_info_t *pwm_info, uint32_t duty);
+void multipwm_set_duty_all(pwm_info_t *pwm_info, uint16_t duty);
 
 /**
  * Start multipwm


### PR DESCRIPTION
The duty parameters is an uint32, but it only uses uint16 as it's maximum value.